### PR TITLE
Update submit.sh.htm

### DIFF
--- a/essentialspackages-installer/usr/share/bigcontrolcenter/categories/system/essentialspackages/submit.sh.htm
+++ b/essentialspackages-installer/usr/share/bigcontrolcenter/categories/system/essentialspackages/submit.sh.htm
@@ -45,14 +45,14 @@ close_header
 if [ "$p_proprietario" = "yes" ]
 then
 
-    proprietario="google-chrome skype google-talkplugin flashplugin-installer" 
+    proprietario="google-chrome-stable skype google-talkplugin flashplugin-installer" 
 
 fi
 
 if [ "$p_javaoracle" = "yes" ]
 then
 
-    javaoracle="oracle-jdk7-installer" 
+    javaoracle="oracle-java8-installer oracle-java8-set-default" 
 
 fi
 


### PR DESCRIPTION
Corrige a instalação do Google Chrome. Atualiza a instalação do Java para a versão 8 e instala um pacote adicional requerido para que o Java da Oracle se torne o padrão do sistema (pacote: oracle-java8-set-default). Os repositórios extras para tal processo são habilitados por este outro script que está nesta página ->  https://github.com/kaiana/core-apps/blob/master/kaiana-iso-generator/usr/share/kaiana/iso-generator/repositories.sh.trusty  . Por LordDan78. 30/05/2015